### PR TITLE
Reuse DB in test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ norecursedirs = [
 addopts = [
     "-p", "no:warnings",
     "--ds=config.settings.test",
-    # "--reuse-db",
+    "--reuse-db",
     "--disable-socket",
     "--allow-hosts=127.0.0.1,127.0.1.1,localhost"
 ]


### PR DESCRIPTION
Bypass migrations application to speed up the tests. Use --create-db to recreate the DB if necessary.