### PR TITLE
User-friendly way to insert question/answer

### DIFF
--- a/qa/admin.py
+++ b/qa/admin.py
@@ -1,43 +1,13 @@
-from django import forms
-from django.contrib import admin
-from django.contrib.contenttypes.models import ContentType
+from django.contrib.contenttypes.admin import GenericStackedInline
 from django.db import models
 from django_summernote.widgets import SummernoteWidget
 
 from .models import QuestionAnswer
 
 
-class QuestionAnswerForm(forms.ModelForm):
-    class Meta:
-        model = QuestionAnswer
-        fields = ["title_fr", "title_en", "content_fr", "content_en", "content_type", "object_id"]
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.fields["content_type"].queryset = ContentType.objects.filter(model__in=["city", "department", "academy"])
-
-    def save(self, commit=True):
-        instance = super().save(commit=False)
-        if instance.content_type and instance.object_id:
-            instance.territory = instance.content_type.get_object_for_this_type(id=instance.object_id)
-        if commit:
-            instance.save()
-        return instance
-
-
-class QuestionAnswerAdmin(admin.ModelAdmin):
-    form = QuestionAnswerForm
-    list_display = ("title_fr", "territory_name")
-    search_fields = ("title_fr", "content_fr")
-
+class QuestionAnswerInline(GenericStackedInline):
+    model = QuestionAnswer
+    extra = 0
     formfield_overrides = {
         models.TextField: {"widget": SummernoteWidget},
     }
-
-    def territory_name(self, obj):
-        return obj.territory.name if obj.territory else ""
-
-    territory_name.short_description = "Territoire"
-
-
-admin.site.register(QuestionAnswer, QuestionAnswerAdmin)

--- a/territories/admin.py
+++ b/territories/admin.py
@@ -1,7 +1,23 @@
 from django.contrib import admin
 
+from qa.admin import QuestionAnswerInline
+
 from .models import Academy, City, Department
 
-admin.site.register(City)
-admin.site.register(Department)
-admin.site.register(Academy)
+
+@admin.register(City)
+class CityAdmin(admin.ModelAdmin):
+    inlines = [QuestionAnswerInline]
+    search_fields = ["name", "postal_codes"]
+
+
+@admin.register(Department)
+class DepartmentAdmin(admin.ModelAdmin):
+    inlines = [QuestionAnswerInline]
+    search_fields = ["name", "code"]
+
+
+@admin.register(Academy)
+class AcademyAdmin(admin.ModelAdmin):
+    inlines = [QuestionAnswerInline]
+    search_fields = ["name"]


### PR DESCRIPTION
Use inline forms from territories to insert question/answer. Much more user-friendly that way. Before this change we had to know the object_id related to the question/answer we were inserting.